### PR TITLE
chore: fix domain ctct to ctct.one

### DIFF
--- a/src/constant/domain.js
+++ b/src/constant/domain.js
@@ -1,7 +1,7 @@
 const domains = {
   ctct: {
     name: 'Chúng Ta Cùng Tiến',
-    domain: 'https://ctct.gdsc.app',
+    domain: 'https://ctct.one',
   },
   fptudsc: {
     name: 'Developer Student Community - FPT University HCMC',


### PR DESCRIPTION
Change default domain for ctct.gdsc.app to ctct.one

![ctct-demo-1](https://github.com/gdsc-hcmut/url-shortener-fe/assets/26504967/298de3d7-924b-4c22-aee4-d720cbeef998)

![ctct-demo-2](https://github.com/gdsc-hcmut/url-shortener-fe/assets/26504967/6954c69e-0488-446f-bdfb-a667c7a359a3)
